### PR TITLE
Request redraws when the state of a dial changes.

### DIFF
--- a/ToasterWidgets/QToasterLookUpTableDial.cpp
+++ b/ToasterWidgets/QToasterLookUpTableDial.cpp
@@ -154,6 +154,7 @@ void QToasterLookUpTableDial::setLookUpTable(QVector<QPair<int,QString>>* lookUp
 
     mMinValueIndex = 0;
     mMaxValueIndex = mLookUpTable->size() - 1;
+    this->setValue(mCurrValue);
   }
 }
 
@@ -208,13 +209,10 @@ void QToasterLookUpTableDial::updateValueText()
 {
   if(mLookUpTable != nullptr)
   {
-    mCurrValueText = mLookUpTable->at((int)mCurrValue).second + " " + mUnit;
+    mCurrValueText = mLookUpTable->at(mCurrValue).second + " " + mUnit;
 
     if(mCurrValueText.startsWith("0.0") && mMinValueIndex < 0)
       mCurrValueText = "<" + mCurrValueText + ">";
-
-    if(mIsActive)
-      emit valueChanged(mCurrValueText);
   }
 }
 
@@ -225,6 +223,7 @@ void QToasterLookUpTableDial::setKnobSize(KnobSize knobSize)
     mKnobSkinPixmaps = &sSmallKnobSkinPixmaps;
   else
     mKnobSkinPixmaps = &sBigKnobSkinPixmaps;
+  QWidget::update();
 }
 
 void QToasterLookUpTableDial::setLEDRingType(LEDRingType ledRingType)
@@ -234,11 +233,12 @@ void QToasterLookUpTableDial::setLEDRingType(LEDRingType ledRingType)
     mLEDRingSkinPixmaps = &sUniLEDRingSkinPixmaps;
   else
     mLEDRingSkinPixmaps = &sBiLEDRingSkinPixmaps;
+  QWidget::update();
 }
 
 void QToasterLookUpTableDial::setValue(int value)
 {
-  if(mLookUpTable != nullptr && mIsActive)
+  if(mLookUpTable != nullptr)
   {
     for(int i = 0; i < mLookUpTable->size(); ++i)
     {
@@ -249,8 +249,10 @@ void QToasterLookUpTableDial::setValue(int value)
     if(mCurrValue > mMaxValueIndex)
       mCurrValue = mMaxValueIndex;
 
-    updateValueText();
-    updateLEDRing();
+    update(0);
+  } else {
+      //Defer lookup in the lookup table until it is set
+      mCurrValue = value;
   }
 }
 
@@ -329,7 +331,7 @@ void QToasterLookUpTableDial::showValueTooltip()
 
 void QToasterLookUpTableDial::updateLEDRing()
 {
-  if(mLEDRingType != None && mIsActive)
+  if(mLEDRingType != None && mLookUpTable != nullptr && mIsActive)
   {
     double step = (mMaxValue - mMinValue) / (sLEDRingSkinNoOfFrames - 1);
     double offset = mMinValue * (-1);
@@ -337,5 +339,7 @@ void QToasterLookUpTableDial::updateLEDRing()
     mCurrLEDRingFrameNo = (int) floor(value + 0.5);
     if(mCurrLEDRingFrameNo >= sLEDRingSkinNoOfFrames)
       mCurrLEDRingFrameNo = sLEDRingSkinNoOfFrames - 1;
+  } else {
+      mCurrLEDRingFrameNo = 0;
   }
 }

--- a/ToasterWidgets/QToasterLookUpTableDial.h
+++ b/ToasterWidgets/QToasterLookUpTableDial.h
@@ -64,7 +64,7 @@ public slots:
   void setLEDRingType(LEDRingType ledType);
   void setValue(int value);
   void setUnit(QString unit);
-  void setIsActive(bool active) { mIsActive = active; }
+  void setIsActive(bool active) { mIsActive = active; update(0); }
 
 protected:
   void createKnobSkin();

--- a/ToasterWidgets/qtoasterdial.cpp
+++ b/ToasterWidgets/qtoasterdial.cpp
@@ -193,6 +193,7 @@ void QToasterDial::setKnobSize(KnobSize knobSize)
     mKnobSkinPixmaps = &sSmallKnobSkinPixmaps;
   else
     mKnobSkinPixmaps = &sBigKnobSkinPixmaps;
+  QWidget::update();
 }
 
 void QToasterDial::setLEDRingType(LEDRingType ledRingType)
@@ -202,6 +203,9 @@ void QToasterDial::setLEDRingType(LEDRingType ledRingType)
     mLEDRingSkinPixmaps = &sUniLEDRingSkinPixmaps;
   else
     mLEDRingSkinPixmaps = &sBiLEDRingSkinPixmaps;
+
+  updateLEDRing();
+  QWidget::update();
 }
 
 void QToasterDial::setMinValue(double minValue)
@@ -210,7 +214,7 @@ void QToasterDial::setMinValue(double minValue)
   {
     mMinValue = minValue;
   }
-  QWidget::update();
+  update(0);
 }
 
 void QToasterDial::setMaxValue(double maxValue)
@@ -219,7 +223,7 @@ void QToasterDial::setMaxValue(double maxValue)
   {
     mMaxValue = maxValue;
   }
-  QWidget::update();
+  update(0);
 }
 
 void QToasterDial::setStepWidth(double stepWidth)
@@ -240,6 +244,7 @@ void QToasterDial::setValue(double value)
     mCurrValue = floor(value * tmp + 0.5) / tmp;
     updateValueText();
     updateLEDRing();
+    QWidget::update();
   }
 }
 

--- a/ToasterWidgets/qtoasterdial.h
+++ b/ToasterWidgets/qtoasterdial.h
@@ -72,7 +72,7 @@ public slots:
   void setPrecision(unsigned int precision) { mPrecision = precision; }
   void setValue(double value);
   void setUnit(QString unit);
-  void setIsActive(bool active) { mIsActive = active; }
+  void setIsActive(bool active) { mIsActive = active; update(0); }
 
 protected:
   void createKnobSkin();

--- a/ToasterWidgets/qtoasterenumdial.cpp
+++ b/ToasterWidgets/qtoasterenumdial.cpp
@@ -186,6 +186,8 @@ void QToasterEnumDial::setKnobSize(KnobSize knobSize)
     mKnobSkinPixmaps = &sSmallKnobSkinPixmaps;
   else
     mKnobSkinPixmaps = &sBigKnobSkinPixmaps;
+
+  QWidget::update();
 }
 
 void QToasterEnumDial::setLEDRingType(LEDRingType ledRingType)
@@ -195,23 +197,30 @@ void QToasterEnumDial::setLEDRingType(LEDRingType ledRingType)
     mLEDRingSkinPixmaps = &sUniLEDRingSkinPixmaps;
   else
     mLEDRingSkinPixmaps = &sBiLEDRingSkinPixmaps;
+
+  QWidget::update();
 }
 
 void QToasterEnumDial::setValues(QStringList values)
 {
   mValues = values;
-  updateValueText();
+  this->setValue(mCurrValueIndex);
   QWidget::update();
 }
 
 void QToasterEnumDial::setValue(int value)
 {
-  if(value >= 0 && value < mValues.size() && mIsActive)
+  if(value >= 0 && value < mValues.size())
   {
     mCurrValueIndex = value;
     updateValueText();
     QWidget::update();
-    emit valueChanged(mCurrValueIndex);
+    if (mIsActive)
+        emit valueChanged(mCurrValueIndex);
+  } else {
+      //Defer updating ValueText until the values have been set
+      if (mValues.empty())
+          mCurrValueIndex = value;
   }
 }
 
@@ -292,5 +301,7 @@ void QToasterEnumDial::updateLEDRing()
     mCurrLEDRingFrameNo = (int) floor(value + 0.5);
     if(mCurrLEDRingFrameNo > sLEDRingSkinNoOfFrames)
       mCurrLEDRingFrameNo = sLEDRingSkinNoOfFrames;
+  } else {
+      mCurrLEDRingFrameNo = 0;
   }
 }

--- a/ToasterWidgets/qtoasterenumdial.h
+++ b/ToasterWidgets/qtoasterenumdial.h
@@ -61,7 +61,7 @@ public slots:
   void setKnobSize(KnobSize knobSize);
   void setLEDRingType(LEDRingType ledType);
   void setValues(QStringList values);
-  void setIsActive(bool enabled) { mIsActive = enabled; }
+  void setIsActive(bool enabled) { mIsActive = enabled; update(0); }
   //void setValue(const QString& value);
   void setValue(int value);
 


### PR DESCRIPTION
Whenever a value gets set on a dial request a update of the widget.
In some cases we also need to recalculate the LED ring updates so
call the internal update function with a zero offset in this case.

Closes #9