### PR TITLE
Add status light for KPA connectivity

### DIFF
--- a/Toaster/ConnectionStatusFrame.cpp
+++ b/Toaster/ConnectionStatusFrame.cpp
@@ -37,10 +37,10 @@ void ConnectionStatusFrame::setMidiStatus(bool isConnected)
   update();
 }
 
-void ConnectionStatusFrame::setKPAStatus(bool isConnected)
+void ConnectionStatusFrame::setKPAStatus(bool isConnected, bool dataReceived)
 {
   if(isConnected)
-    ui.kpaStatusLed->setColor(QMultiColorLed::Green);
+    ui.kpaStatusLed->setColor(dataReceived ? QMultiColorLed::Green : QMultiColorLed::Red);
   else
     ui.kpaStatusLed->setColor(QMultiColorLed::Off);
   update();

--- a/Toaster/ConnectionStatusFrame.h
+++ b/Toaster/ConnectionStatusFrame.h
@@ -29,7 +29,7 @@ public:
 
 public slots:
   void setMidiStatus(bool isConnected);
-  void setKPAStatus(bool isConnected);
+  void setKPAStatus(bool isConnected, bool dataReceived);
 
 private:
   Ui::ConnectionStatusFrame ui;

--- a/Toaster/Midi.cpp
+++ b/Toaster/Midi.cpp
@@ -105,10 +105,11 @@ void Midi::processMidiInput(std::vector<unsigned char> *msg)
 {
   if(msg && msg->size() > 0)
   {
+    auto bytes = ByteArray::fromStdVector(*msg);
     for(IMidiConsumer* consumer : mConsumer)
     {
       if((*msg)[0] == consumer->getStatusByte())
-        consumer->consume(ByteArray::fromStdVector(*msg));
+        consumer->consume(bytes);
     }
   }
 }

--- a/Toaster/ToasterWindow.cpp
+++ b/Toaster/ToasterWindow.cpp
@@ -30,6 +30,7 @@ ToasterWindow::ToasterWindow(QWidget *parent)
   , ui(new Ui::ToasterWindow)
   , mIsConnected2Midi(false)
   , mIsConnected2KPA(false)
+  , mDataReceivedfromKPA(false)
 {
   ui->setupUi(this);
   ui->statusBar->addPermanentWidget(&mConnectionStatus);
@@ -38,21 +39,22 @@ ToasterWindow::ToasterWindow(QWidget *parent)
   setWindowTitle(title);
 
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool) { ui->actionUploadKIPRFile->setEnabled(midiConnected); });
+          [=](bool midiConnected, bool, bool) { ui->actionUploadKIPRFile->setEnabled(midiConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool) { ui->actionClose_MIDI_Ports->setEnabled(midiConnected); });
+          [=](bool midiConnected, bool, bool) { ui->actionClose_MIDI_Ports->setEnabled(midiConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool) { ui->actionRequestValues->setEnabled(midiConnected); });
+          [=](bool midiConnected, bool, bool) { ui->actionRequestValues->setEnabled(midiConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool) { ui->actionOpenMIDIPorts->setDisabled(midiConnected); });
+          [=](bool midiConnected, bool, bool) { ui->actionOpenMIDIPorts->setDisabled(midiConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool kpaConnected) { ui->actionDisconnectFromKPA->setEnabled(midiConnected && kpaConnected); });
+          [=](bool midiConnected, bool kpaConnected, bool) { ui->actionDisconnectFromKPA->setEnabled(midiConnected && kpaConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool kpaConnected) { ui->actionConnectToKPA->setEnabled(midiConnected && !kpaConnected);});
+          [=](bool midiConnected, bool kpaConnected, bool) { ui->actionConnectToKPA->setEnabled(midiConnected && !kpaConnected);});
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool) { mConnectionStatus.setMidiStatus(midiConnected); });
+          [=](bool midiConnected, bool, bool) { mConnectionStatus.setMidiStatus(midiConnected); });
   connect(this, &ToasterWindow::connectionStatusChanged,
-          [=](bool midiConnected, bool kpaConnected) { mConnectionStatus.setKPAStatus(midiConnected && kpaConnected); });
+          [=](bool midiConnected, bool kpaConnected, bool dataReceived)
+  { mConnectionStatus.setKPAStatus(midiConnected && kpaConnected, dataReceived); });
 
   if(!Settings::get().getDebuggerActive())
     ui->menuDebug->menuAction()->setVisible(false);
@@ -76,6 +78,7 @@ ToasterWindow::ToasterWindow(QWidget *parent)
 ToasterWindow::~ToasterWindow()
 {
   ui->mainFrame->disconnectFromKPA();
+  Midi::get().removeConsumer(this);
   Midi::get().closePorts();
   if(ui != nullptr)
     delete ui;
@@ -83,11 +86,13 @@ ToasterWindow::~ToasterWindow()
 
 void ToasterWindow::onStartup()
 {
+  Midi::get().addConsumer(this);
   QString connectName("Toaster ");
   ui->mainFrame->connect2KPA(connectName);
   ui->mainFrame->requestValues();
   mIsConnected2KPA = true;
-  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA);
+  mDataReceivedfromKPA = false;
+  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA, mDataReceivedfromKPA);
 }
 
 void ToasterWindow::on_actionRequestValues_triggered()
@@ -121,6 +126,9 @@ void ToasterWindow::openMidiPorts()
     }
 
     mIsConnected2Midi = Midi::get().openPorts(inPort, outPort);
+    // As we've just opened the midi connection assume
+    // we've not heard from the KPA yet
+    mDataReceivedfromKPA = false;
   }
   else
   {
@@ -130,7 +138,9 @@ void ToasterWindow::openMidiPorts()
   if(mIsConnected2Midi)
     ui->statusBar->showMessage("Midi connected");
 
-  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA);
+  emit connectionStatusChanged(mIsConnected2Midi,
+                               mIsConnected2KPA,
+                               mDataReceivedfromKPA);
 }
 
 void ToasterWindow::on_actionCmd_triggered()
@@ -368,7 +378,10 @@ void ToasterWindow::on_actionClose_MIDI_Ports_triggered()
   Midi::get().closePorts();
   mIsConnected2KPA = false;
   mIsConnected2Midi = false;
-  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA);
+  mDataReceivedfromKPA = false;
+  emit connectionStatusChanged(mIsConnected2Midi,
+                               mIsConnected2KPA,
+                               mDataReceivedfromKPA);
 }
 
 void ToasterWindow::on_actionConnectToKPA_triggered()
@@ -376,14 +389,20 @@ void ToasterWindow::on_actionConnectToKPA_triggered()
   QString connectName("Toaster ");
   ui->mainFrame->connect2KPA(connectName);
   mIsConnected2KPA = true;
-  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA);
+  mDataReceivedfromKPA = false;
+  emit connectionStatusChanged(mIsConnected2Midi,
+                               mIsConnected2KPA,
+                               mDataReceivedfromKPA);
 }
 
 void ToasterWindow::on_actionDisconnectFromKPA_triggered()
 {
   ui->mainFrame->disconnectFromKPA();
   mIsConnected2KPA = false;
-  emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA);
+  mDataReceivedfromKPA = false;
+  emit connectionStatusChanged(mIsConnected2Midi,
+                               mIsConnected2KPA,
+                               mDataReceivedfromKPA);
 }
 
 void ToasterWindow::on_actionExit_triggered()

--- a/Toaster/ToasterWindow.h
+++ b/Toaster/ToasterWindow.h
@@ -19,12 +19,13 @@
 #include <QMainWindow>
 #include <QLabel>
 #include "ConnectionStatusFrame.h"
+#include "MidiConsumer.h"
 
 namespace Ui {
 class ToasterWindow;
 }
 
-class ToasterWindow : public QMainWindow
+class ToasterWindow : public QMainWindow, public IMidiConsumer
 {
     Q_OBJECT
 
@@ -33,7 +34,7 @@ public:
     ~ToasterWindow();
 
 signals:
-  void connectionStatusChanged(bool midiConnected, bool kpaConnected);
+  void connectionStatusChanged(bool midiConnected, bool kpaConnected, bool kpaDataReceived);
 
 private slots:
   void onStartup();
@@ -55,6 +56,12 @@ private slots:
   void on_actionEditKIPRFile_triggered();
 
 private:
+  unsigned char getStatusByte() override { return 0xF0; }
+  void consume(const ByteArray&) override {
+      mDataReceivedfromKPA = true;
+      emit connectionStatusChanged(mIsConnected2Midi, mIsConnected2KPA, mDataReceivedfromKPA);
+  }
+
   //QTimer* timer;
   void showSettingsDialog();
   void openMidiPorts();
@@ -63,6 +70,7 @@ private:
 
   bool mIsConnected2Midi;
   bool mIsConnected2KPA;
+  bool mDataReceivedfromKPA;
 
   ConnectionStatusFrame mConnectionStatus;
 };


### PR DESCRIPTION
If we've not received any data from the KPA then show the status LED
as red instead of green so the user knows there is some midi
connectivity issue.